### PR TITLE
Adding anchor management (considered as is if slug begins with "#")

### DIFF
--- a/application/libraries/Multi_menu.php
+++ b/application/libraries/Multi_menu.php
@@ -3,11 +3,11 @@
 /**
  * Codeigniter Multilevel menu Class
  * Provide easy way to render multi level menu
- * 
+ *
  * @package			CodeIgniter
  * @subpackage		Libraries
  * @category		Libraries
- * @author			Eding Muhamad Saprudin 
+ * @author			Eding Muhamad Saprudin
  * @link    		https://github.com/edomaru/codeigniter_multilevel_menu
  */
 class Multi_menu {
@@ -15,7 +15,7 @@ class Multi_menu {
 	/**
 	 * Tag opener of the navigation menu
 	 * default is '<ul>' tag
-	 * 
+	 *
 	 * @var string
 	 */
 	private $nav_tag_open             = '<ul>';
@@ -23,15 +23,15 @@ class Multi_menu {
 	/**
 	 * Closing tag of the navigation menu
 	 * default is '</ul>'
-	 * 
+	 *
 	 * @var string
 	 */
-	private $nav_tag_close            = '</ul>';	
+	private $nav_tag_close            = '</ul>';
 
 	/**
 	 * Tag opening tag of the menu item
 	 * default is '</li>'
-	 * 
+	 *
 	 * @var string
 	 */
 	private $item_tag_open            = '<li>';
@@ -39,7 +39,7 @@ class Multi_menu {
 	/**
 	 * Closing tag of the menu item
 	 * default is '</li>'
-	 * 
+	 *
 	 * @var string
 	 */
 	private $item_tag_close           = '</li>';
@@ -47,7 +47,7 @@ class Multi_menu {
 	/**
 	 * Opening tag of the menu item that has children
 	 * default is '</li>'
-	 * 
+	 *
 	 * @var string
 	 */
 	private $parent_tag_open          = '<li>';
@@ -55,7 +55,7 @@ class Multi_menu {
 	/**
 	 * Closing tag of the menu item that has children
 	 * default is '</li>'
-	 * 
+	 *
 	 * @var string
 	 */
 	private $parent_tag_close         = '</li>';
@@ -63,7 +63,7 @@ class Multi_menu {
 	/**
 	 * Anchor tag of the menu item that has children
 	 * default is '<a href="%s">%s</a>'
-	 * 
+	 *
 	 * @var string
 	 */
 	private $parent_anchor            = '<a href="%s">%s</a>';
@@ -71,7 +71,7 @@ class Multi_menu {
 	/**
 	 * Opening tag of the menu item level one that has children
 	 * if not definied or empty, it would use $parent_tag_open
-	 * 
+	 *
 	 * @var string
 	 */
 	private $parentl1_tag_open        = '';
@@ -79,7 +79,7 @@ class Multi_menu {
 	/**
 	 * Closing tag of the menu item level one that has children
 	 * if not definied or empty, it would use $parent_tag_close
-	 * 
+	 *
 	 * @var string
 	 */
 	private $parentl1_tag_close       = '';
@@ -87,7 +87,7 @@ class Multi_menu {
 	/**
 	 * Anchor tag of the menu item level one that has children
 	 * if not definied or empty, it would use $parent_anchor
-	 * 
+	 *
 	 * @var string
 	 */
 	private $parentl1_anchor          = '';
@@ -95,7 +95,7 @@ class Multi_menu {
 	/**
 	 * Opening tag of the children menu / sub menu.
 	 * Default is '<ul>'
-	 * 
+	 *
 	 * @var string
 	 */
 	private $children_tag_open        = '<ul>';
@@ -103,7 +103,7 @@ class Multi_menu {
 	/**
 	 * Closing tag of the children menu / sub menu.
 	 * Default is '<ul>'
-	 * 
+	 *
 	 * @var string
 	 */
 	private $children_tag_close       = '</ul>';
@@ -111,37 +111,37 @@ class Multi_menu {
 	/**
 	 * The active item class
 	 * Default is 'active'
-	 * 
+	 *
 	 * @var string
 	 */
-	private $item_active_class        = 'active';	
+	private $item_active_class        = 'active';
 
 	/**
 	 * The item that has active class.
 	 * Please specify the menu slug here
-	 * 
+	 *
 	 * @var string
 	 */
-	private $item_active              = '';	
+	private $item_active              = '';
 
 	/**
 	 * Anchor tag of the menu item.
 	 * Default is '<a href="%s">%s</a>'
-	 * 
+	 *
 	 * @var string
 	 */
 	private $item_anchor              = '<a href="%s">%s</a>';
 
 	/**
 	 * The list of menu items that has divider
-	 * 
+	 *
 	 * @var string
 	 */
 	private $divided_items_list       = array();
 
 	/**
 	 * number of the items that has divider
-	 * 
+	 *
 	 * @var string
 	 */
 	private $divided_items_list_count = 0;
@@ -149,7 +149,7 @@ class Multi_menu {
 	/**
 	 * Divider of the item
 	 * ex: '<li class="divider"></li>'
-	 * 
+	 *
 	 * @var string
 	 */
 	private $item_divider             = '';
@@ -157,7 +157,7 @@ class Multi_menu {
 	/**
 	 * Array key that holds Menu id
 	 * Ex: $items['id'] = 1
-	 * 
+	 *
 	 * @var string
 	 */
 	private $menu_id                  = 'id';
@@ -165,15 +165,15 @@ class Multi_menu {
 	/**
 	 * Array key that holds Menu label
 	 * Ex: $items['name'] = "Something"
-	 * 
+	 *
 	 * @var string
 	 */
-	private $menu_label               = 'name';	
+	private $menu_label               = 'name';
 
 	/**
 	 * Array key that holds Menu key/ menu slug
 	 * Ex: $items['key'] = "something"
-	 * 
+	 *
 	 * @var string
 	 */
 	private $menu_key                 = 'key';
@@ -181,23 +181,23 @@ class Multi_menu {
 	/**
 	 * Array key that holds Menu parent
 	 * Ex: $items['parent'] = 1
-	 * 
+	 *
 	 * @var string
 	 */
-	private $menu_parent              = 'parent';	
+	private $menu_parent              = 'parent';
 
 	/**
 	 * Array key that holds Menu Ordering
 	 * Ex: $items['order'] = 1
-	 * 
+	 *
 	 * @var string
 	 */
-	private $menu_order               = 'order';	
+	private $menu_order               = 'order';
 
 	/**
 	 * Array key that holds Menu Icon
 	 * Ex: $items['icon'] = "fa fa-list"
-	 * 
+	 *
 	 * @var string
 	 */
 	private $menu_icon               = 'icon';
@@ -205,7 +205,7 @@ class Multi_menu {
 	/**
 	 * Position of the menu icon
 	 * left or right
-	 * 
+	 *
 	 * @var string
 	 */
 	private $icon_position           = 'left';
@@ -214,37 +214,37 @@ class Multi_menu {
 	 * Base url of the image icon (draft)
 	 * It would be use codeigniter base url if not define
 	 * Ex: http://localhost/assets/img
-	 * 
+	 *
 	 * @var string
 	 */
 	private $icon_img_base_url       = null;
 
 	/**
 	 * List of the menus icon
-	 * 
+	 *
 	 * @var string
 	 */
 	private $menu_icons_list         = null;
 
 	/**
 	 * Store additional menu items
-	 * 
+	 *
 	 * @var string
 	 */
 	private $_additional_item        = array();
 
 	/**
 	 * Uri segment
-	 * 
+	 *
 	 * @var int
 	 */
 	private $uri_segment             = 1;
-	
+
 
 	/**
 	 * load configuration on config/multi_menu.php
-	 * 
-	 * @param array $config 
+	 *
+	 * @param array $config
 	 */
 	public function __construct($config = array())
 	{
@@ -257,9 +257,9 @@ class Multi_menu {
 
 	/**
 	 * Initialize multi level menu configuration
-	 * 
+	 *
 	 * @param  array  $config multi level menu configuration
-	 * @return void         
+	 * @return void
 	 */
 	public function initialize($config = array())
 	{
@@ -272,13 +272,13 @@ class Multi_menu {
 
 	/**
 	 * Specify what items would be divided
-	 * 
+	 *
 	 * @param array  $items   array of menu key
 	 * @param string $divider divider
 	 */
 	public function set_divided_items($items = array(), $divider = null)
 	{
-		if ( count($items) ) 
+		if ( count($items) )
 		{
 			$this->divided_items_list       = $items;
 			$this->item_divider             = $divider ? $divider : $this->item_divider;
@@ -291,24 +291,24 @@ class Multi_menu {
      *
      * @param  boolean 	$config      			configuration of the library. if not defined would use default config.
      *                                  		It also possible to define active item of the menu here with string value.
-     * @param  array 	$divided_items_list 	menu items that would be divided   
+     * @param  array 	$divided_items_list 	menu items that would be divided
      * @param  string 	$divider 				divider item
-     * @return string               
+     * @return string
      */
     public function render($config = array(), $divided_items_list = array(), $divider = '')
     {
 		$html  = "";
 
 		if ( is_array($config) ) {
-			$this->initialize($config);	
+			$this->initialize($config);
 		}
 		elseif (is_string($config)) {
 			$this->item_active = $config;
 		}
 
-    	if ( count($this->items) ) 
+    	if ( count($this->items) )
     	{
-			$items = $this->prepare_items($this->items);		
+			$items = $this->prepare_items($this->items);
 
 			$this->set_divided_items($divided_items_list, $divider);
 
@@ -316,11 +316,11 @@ class Multi_menu {
     	}
 
         return $html;
-    } 
+    }
 
     /**
      * Set array data
-     * 
+     *
      * @param array $items data which would be rendered
      */
     public function set_items($items = array())
@@ -330,26 +330,26 @@ class Multi_menu {
 
     /**
      * Prepare item before render
-     * 
+     *
      * @param  array 	$data   array data from active record result_array()
      * @param  int 		$parent parent of items
-     * @return array         
+     * @return array
      */
     private function prepare_items(array $data, $parent = null)
     {
     	$items = array();
 
-		foreach ($data as $item) 
+		foreach ($data as $item)
 		{
-			if ($item[$this->menu_parent] == $parent) 
+			if ($item[$this->menu_parent] == $parent)
 			{
 				$items[$item[$this->menu_id]] = $item;
 				$items[$item[$this->menu_id]]['children'] = $this->prepare_items($data, $item[$this->menu_id]);
-			}	
+			}
 		}
 
 		// after items constructed
-		// sort array by order 
+		// sort array by order
 		usort($items,array($this, 'sort_by_order'));
 
 		return $items;
@@ -357,7 +357,7 @@ class Multi_menu {
 
     /**
      * Sort array by order
-     * 
+     *
      * @param  array $a the 1st array would be compared
      * @param  array $b the 2nd array would be compared
      * @return int
@@ -369,14 +369,14 @@ class Multi_menu {
 
     /**
      * Render data into menu items
-     * 
+     *
      * @param  array  $items  consructed data
      * @param  string &$html  html menu
-     * @return void         
+     * @return void
      */
     private function render_item($items, &$html = '')
-	{	    
-	    if ( empty($html) ) 
+	{
+	    if ( empty($html) )
 	    {
 	    	$nav_tag_opened = true;
 			$html .= $this->nav_tag_open;
@@ -385,15 +385,15 @@ class Multi_menu {
 			if ( ! empty($this->_additional_item['first'])) {
 				$html .= $this->_additional_item['first'];
 			}
-		}		
+		}
 		else {
-	    	$html .= $this->children_tag_open; 
-		}		
-	  
+	    	$html .= $this->children_tag_open;
+		}
+
 	    foreach ($items as $item)
 	    {
 	        // menu label
-	        if ( isset($item[$this->menu_label], $item[$this->menu_key]) ) 
+	        if ( isset($item[$this->menu_label], $item[$this->menu_key]) )
 	        {
 		        $label = $item[$this->menu_label];
 
@@ -401,9 +401,9 @@ class Multi_menu {
 		        $icon  = empty($item[$this->menu_icon]) ? '' : $item[$this->menu_icon];
 		        if ( isset($this->menu_icons_list[($item[$this->menu_key])]) ) {
 		        	$icon = $this->menu_icons_list[($item[$this->menu_key])];
-		        }		        
+		        }
 
-		        if ($icon) 
+		        if ($icon)
 		        {
 		        	$icon = "<i class='{$icon}'></i>";
 		        	$label = trim( $this->icon_position == 'right' ? ($label . " " . $icon ) : ($icon . " " . $label) );
@@ -414,46 +414,47 @@ class Multi_menu {
 		        $slug  = $item[$this->menu_key];
 
 		        // has children or not
-		        $has_children = ! empty($item['children']);	        
+		        $has_children = ! empty($item['children']);
 
-		        // if menu item need separator 
+		        // if menu item need separator
 		        if ($this->divided_items_list_count > 0 && in_array($slug, $this->divided_items_list)) {
-		        	$html .= $this->item_divider;	
+		        	$html .= $this->item_divider;
 		        }
 
-		        if ($has_children) 
+		        if ($has_children)
 		        {
-		        	if ( is_null($item[$this->menu_parent]) && $this->parentl1_tag_open != '' ) 
+		        	if ( is_null($item[$this->menu_parent]) && $this->parentl1_tag_open != '' )
 		        	{
 						$tag_open    =  $this->parentl1_tag_open;
 						$item_anchor = $this->parentl1_anchor != '' ? $this->parentl1_anchor : $this->parent_anchor;
 		        	}
-		        	else 
+		        	else
 		        	{
 						$tag_open     = $this->parent_tag_open;
 						$item_anchor = $this->parent_anchor;
 		        	}
 
-					$href  = '#';				
+					$href  = '#';
 		        }
-		        else 
+		        else
 		        {
 		        	$tag_open    = $this->item_tag_open;
-					$href        = site_url($slug);
+							// if slug begins with # : this is an anchor inside the same page
+							$href = (substr($slug, 0, 1) === "#") ? $slug : site_url($slug);
 					$item_anchor = $this->item_anchor;
 		        }
 
-				$html .= $this->set_active($tag_open, $slug);	        	        
+				$html .= $this->set_active($tag_open, $slug);
 
 				if (substr_count($item_anchor, '%s') == 2) {
 					$html .= sprintf($item_anchor, $href, $label);
 				}
 				else {
-					$html .= sprintf($item_anchor, $label);	
+					$html .= sprintf($item_anchor, $label);
 				}
 
-		        if ( $has_children ) 
-		        {	        	
+		        if ( $has_children )
+		        {
 		            $this->render_item($item['children'], $html);
 
 		            if ( is_null($item[$this->menu_parent]) && $this->parentl1_tag_close != '' ) {
@@ -461,24 +462,24 @@ class Multi_menu {
 		        	}
 		        	else {
 						$html  .= $this->parent_tag_close;
-		        	}	            
+		        	}
 		        }
 		        else {
-		        	$html .= $this->item_tag_close; 
+		        	$html .= $this->item_tag_close;
 		        }
 
 	        }
 	    }
-	    
-	    if (isset($nav_tag_opened)) 
+
+	    if (isset($nav_tag_opened))
 	    {
 	    	if ( ! empty($this->_additional_item['last'])) {
 				$html .= $this->_additional_item['last'];
 			}
 
-	    	$html .= $this->nav_tag_close; 
+	    	$html .= $this->nav_tag_close;
 	    }
-	    else {	   
+	    else {
 	    	$html  .= $this->children_tag_close;
 	    }
 	}
@@ -486,10 +487,10 @@ class Multi_menu {
 	/**
 	 * Inject item to menu
 	 * Call this method before render method call
-	 * 
+	 *
 	 * @param  string $item     menu item that would be injected
 	 * @param  string $position position where the additiona menu item would be placed (fist or last)
-	 * @return Multi_menu           
+	 * @return Multi_menu
 	 */
 	public function inject_item($item, $position = null)
 	{
@@ -504,7 +505,7 @@ class Multi_menu {
 
 	/**
 	 * Set active item
-	 * 
+	 *
 	 * @param string $html html tag that would be injected
 	 * @param string $slug html tag that has injected with active class
 	 */
@@ -512,7 +513,7 @@ class Multi_menu {
 	{
 		$segment = $this->ci->uri->segment($this->uri_segment);
 
-		if ( ($this->item_active != '' && $slug == $this->item_active && empty($segment)) || $slug == $segment) 
+		if ( ($this->item_active != '' && $slug == $this->item_active && empty($segment)) || $slug == $segment)
 		{
 			$doc = new DOMDocument();
 			$doc->loadHTML($html);


### PR DESCRIPTION
This is useful for single page apps.
I consider menu item as an anchor if its slug begins with "#".
In this case the href link is the slug, and not a CI site_url call.